### PR TITLE
Update package homepage URL

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule DurableServer.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      homepage_url: "https://github.com/chrismccord/durable_server",
+      homepage_url: "https://github.com/phoenixframework/durable_server",
       description: """
       DurableServer provides durable, distributed GenServer processes backed by object storage.
       """


### PR DESCRIPTION
Updates the package homepage URL to point at the phoenixframework/durable_server repository.